### PR TITLE
Defer updating settings until the settings dialog is closed. Fixes https...

### DIFF
--- a/Classes/EPubSettings.h
+++ b/Classes/EPubSettings.h
@@ -52,5 +52,6 @@ typedef enum {
 @property (nonatomic, assign) EPubSettingsSyntheticSpread syntheticSpread;
 
 + (EPubSettings *)shared;
+- (void) update;
 
 @end

--- a/Classes/EPubSettings.m
+++ b/Classes/EPubSettings.m
@@ -55,6 +55,10 @@ NSString * const kSDKLauncherEPubSettingsDidChange = @"SDKLauncherEPubSettingsDi
 }
 
 
+- (void) update {
+    [self postNotification];
+}
+
 - (NSDictionary *)dictionary {
 	EPubSettingsScroll scroll = [Settings shared].scroll;
 	EPubSettingsSyntheticSpread syntheticSpread = [Settings shared].syntheticSpread;
@@ -91,7 +95,6 @@ NSString * const kSDKLauncherEPubSettingsDidChange = @"SDKLauncherEPubSettingsDi
 - (void)setColumnGap:(CGFloat)columnGap {
 	if ([Settings shared].columnGap != columnGap) {
 		[Settings shared].columnGap = columnGap;
-		[self postNotification];
 	}
 }
 
@@ -99,7 +102,6 @@ NSString * const kSDKLauncherEPubSettingsDidChange = @"SDKLauncherEPubSettingsDi
 - (void)setFontScale:(CGFloat)fontScale {
 	if ([Settings shared].fontScale != fontScale) {
 		[Settings shared].fontScale = fontScale;
-		[self postNotification];
 	}
 }
 
@@ -107,7 +109,6 @@ NSString * const kSDKLauncherEPubSettingsDidChange = @"SDKLauncherEPubSettingsDi
 - (void)setScroll:(EPubSettingsScroll)scroll {
 	if ([Settings shared].scroll != scroll) {
 		[Settings shared].scroll = scroll;
-		[self postNotification];
 	}
 }
 
@@ -115,7 +116,6 @@ NSString * const kSDKLauncherEPubSettingsDidChange = @"SDKLauncherEPubSettingsDi
 - (void)setSyntheticSpread:(EPubSettingsSyntheticSpread)syntheticSpread {
 	if ([Settings shared].syntheticSpread != syntheticSpread) {
 		[Settings shared].syntheticSpread = syntheticSpread;
-		[self postNotification];
 	}
 }
 

--- a/Classes/EPubSettingsController.m
+++ b/Classes/EPubSettingsController.m
@@ -195,15 +195,18 @@
 
 - (void)onColumnGapDidChange:(UIStepper *)stepper {
 	[EPubSettings shared].columnGap = stepper.value;
+    [self updateCells];
 }
 
 
 - (void)onFontScaleDidChange:(UIStepper *)stepper {
 	[EPubSettings shared].fontScale = stepper.value;
+    [self updateCells];
 }
 
 
 - (void)onTapDone {
+    [[EPubSettings shared] update];
 	[self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -241,6 +244,8 @@
 	else if (cell == m_cellSyntheticSpreadSingle) {
 		[EPubSettings shared].syntheticSpread = EPubSettingsSyntheticSpreadSingle;
 	}
+    
+    [self updateCells];
 }
 
 


### PR DESCRIPTION
A settings update causes a large memory spike (dependant on the size of the spine item currently open). If a user repeatedly increments the font size (originally described in #22) the app will crash. This change defers updating settings until the dialog is actually closed therefore limiting the number of memory spikes. 
