### PR TITLE
add security exception for ios9 non-https requests

### DIFF
--- a/SDKLauncher-iOS-Info.plist
+++ b/SDKLauncher-iOS-Info.plist
@@ -55,6 +55,10 @@
 	<string>0.18.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict/>
+	<key>NSAllowArbitraryLoads</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
This fixes the error that is caused in the launcher when non https resources are loaded due to the new security restrictions in iOS 9