### PR TITLE
iOS 9 App Transport Security: change to localhost and whitelist in plist

### DIFF
--- a/Classes/EPubViewController.m
+++ b/Classes/EPubViewController.m
@@ -606,30 +606,30 @@
 		if ([url isEqualToString:@"readerDidInitialize"]) {
 			NSMutableDictionary *dict = [NSMutableDictionary dictionary];
 
-            //
-            // Important!  Rather than "localhost", "127.0.0.1" is specified in the following URL to work
-            // around an issue introduced in iOS 7.0.  When an iOS 7 device is offline (Wi-Fi off, or
-            // airplane mode on), audio and video refuses to be served by UIWebView / QuickTime, even
-            // though being offline is irrelevant for an embedded HTTP server like ours.  Daniel suggested
-            // trying 127.0.0.1 in case the underlying issue was host name resolution, and it worked!
-            //
-            //   -- Shane
-            //
-            // In order to successfully use http with a local server with the iOS 9 App Transport Security
-            // requirements, use "localhost" instead of "127.0.0.1" below. Also added a plist exception for the
-            // localhost domain under NSAppTransportSecurity. The "localhost" change is required to whitelist a domain
-            // because an ip address unfortunately cannot be used in the NSAppTransportSecurity plist exception.
-            // - msintov, 9/30/2015
-            
-            NSString *rootURLDomain = @"localhost";
-            if (([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedAscending)) {
-                rootURLDomain = @"127.0.0.1";
+			//
+			// Important!  Rather than "localhost", "127.0.0.1" is specified in the following URL to work
+			// around an issue introduced in iOS 7.0.  When an iOS 7 device is offline (Wi-Fi off, or
+			// airplane mode on), audio and video refuses to be served by UIWebView / QuickTime, even
+			// though being offline is irrelevant for an embedded HTTP server like ours.  Daniel suggested
+			// trying 127.0.0.1 in case the underlying issue was host name resolution, and it worked!
+			//
+			//   -- Shane
+			//
+			// In order to successfully use http with a local server with the iOS 9 App Transport Security
+			// requirements, use "localhost" instead of "127.0.0.1" below. Also added a plist exception for the
+			// localhost domain under NSAppTransportSecurity. The "localhost" change is required to whitelist a domain
+			// because an ip address unfortunately cannot be used in the NSAppTransportSecurity plist exception.
+			// - msintov, 9/30/2015
+
+			NSString *rootURLDomain = @"localhost";
+			if (([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedAscending)) {
+				rootURLDomain = @"127.0.0.1";
             }
-            
-            if (m_package.rootURL == nil || m_package.rootURL.length == 0) {
-                m_package.rootURL = [NSString stringWithFormat:
+
+			if (m_package.rootURL == nil || m_package.rootURL.length == 0) {
+				m_package.rootURL = [NSString stringWithFormat:
                                      @"http://%@:%d/", rootURLDomain, m_resourceServer.port];
-            }            
+			}
             
 			[dict setObject:m_package.dictionary forKey:@"package"];
 			[dict setObject:[EPubSettings shared].dictionary forKey:@"settings"];

--- a/Classes/EPubViewController.m
+++ b/Classes/EPubViewController.m
@@ -606,21 +606,31 @@
 		if ([url isEqualToString:@"readerDidInitialize"]) {
 			NSMutableDictionary *dict = [NSMutableDictionary dictionary];
 
-			//
-			// Important!  Rather than "localhost", "127.0.0.1" is specified in the following URL to work
-			// around an issue introduced in iOS 7.0.  When an iOS 7 device is offline (Wi-Fi off, or
-			// airplane mode on), audio and video refuses to be served by UIWebView / QuickTime, even
-			// though being offline is irrelevant for an embedded HTTP server like ours.  Daniel suggested
-			// trying 127.0.0.1 in case the underlying issue was host name resolution, and it worked!
-			//
-			//   -- Shane
-			//
-
-			if (m_package.rootURL == nil || m_package.rootURL.length == 0) {
-				m_package.rootURL = [NSString stringWithFormat:
-					@"http://127.0.0.1:%d/", m_resourceServer.port];
-			}
-
+            //
+            // Important!  Rather than "localhost", "127.0.0.1" is specified in the following URL to work
+            // around an issue introduced in iOS 7.0.  When an iOS 7 device is offline (Wi-Fi off, or
+            // airplane mode on), audio and video refuses to be served by UIWebView / QuickTime, even
+            // though being offline is irrelevant for an embedded HTTP server like ours.  Daniel suggested
+            // trying 127.0.0.1 in case the underlying issue was host name resolution, and it worked!
+            //
+            //   -- Shane
+            //
+            // In order to successfully use http with a local server with the iOS 9 App Transport Security
+            // requirements, use "localhost" instead of "127.0.0.1" below. Also added a plist exception for the
+            // localhost domain under NSAppTransportSecurity. The "localhost" change is required to whitelist a domain
+            // because an ip address unfortunately cannot be used in the NSAppTransportSecurity plist exception.
+            // - msintov, 9/30/2015
+            
+            NSString *rootURLDomain = @"localhost";
+            if (([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedAscending)) {
+                rootURLDomain = @"127.0.0.1";
+            }
+            
+            if (m_package.rootURL == nil || m_package.rootURL.length == 0) {
+                m_package.rootURL = [NSString stringWithFormat:
+                                     @"http://%@:%d/", rootURLDomain, m_resourceServer.port];
+            }            
+            
 			[dict setObject:m_package.dictionary forKey:@"package"];
 			[dict setObject:[EPubSettings shared].dictionary forKey:@"settings"];
 

--- a/SDKLauncher-iOS-Info.plist
+++ b/SDKLauncher-iOS-Info.plist
@@ -39,6 +39,29 @@
 			<true/>
 		</dict>
 	</dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionMinimumTLSVersion</key>
+				<string>TLSv1.2</string>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<false/>
+				<key>NSThirdPartyExceptionMinimumTLSVersion</key>
+				<string>TLSv1.2</string>
+				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+				<true/>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>org.readium.SDKLauncher.iOS</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
iOS 9 App Transport Security doesn't allow http requests by default. Added "localhost" to the whitelisted list of domains in the plist. Also changed "127.0.0.1" to "locallhost" in EPubViewController.m for iOS 9 and above only. Tested that in airplane mode with Wi-Fi off on iOS 9, media overlays, audio and video still play.