### PR TITLE
RDContainer.mm/h are attached which are detached from the Readium SDK project.

### DIFF
--- a/Classes/RDContainer.h
+++ b/Classes/RDContainer.h
@@ -1,0 +1,50 @@
+//
+//  RDContainer.h
+//  RDServices
+//
+//  Created by Shane Meyer on 2/4/13.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+@class RDContainer;
+
+@protocol RDContainerDelegate <NSObject>
+
+- (BOOL)container:(RDContainer *)container handleSdkError:(NSString *)message isSevereEpubError:(BOOL)isSevereEpubError;
+
+@end
+
+@class RDPackage;
+
+@interface RDContainer : NSObject
+
+@property (nonatomic, readonly) RDPackage *firstPackage;
+@property (nonatomic, readonly) NSArray *packages;
+@property (nonatomic, readonly) NSString *path;
+
+- (instancetype)initWithDelegate:(id <RDContainerDelegate>)delegate path:(NSString *)path;
+
+@end

--- a/Classes/RDContainer.mm
+++ b/Classes/RDContainer.mm
@@ -1,0 +1,108 @@
+//
+//  RDContainer.mm
+//  RDServices
+//
+//  Created by Shane Meyer on 2/4/13.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "RDContainer.h"
+#import <ePub3/container.h>
+#import <ePub3/initialization.h>
+#import <ePub3/utilities/error_handler.h>
+#import "RDPackage.h"
+
+
+@interface RDContainer () {
+	@private std::shared_ptr<ePub3::Container> m_container;
+	@private __weak id <RDContainerDelegate> m_delegate;
+	@private NSMutableArray *m_packages;
+	@private ePub3::Container::PackageList m_packageList;
+	@private NSString *m_path;
+}
+
+@end
+
+
+@implementation RDContainer
+
+
+@synthesize packages = m_packages;
+@synthesize path = m_path;
+
+
+- (RDPackage *)firstPackage {
+	return m_packages.count == 0 ? nil : [m_packages objectAtIndex:0];
+}
+
+
+- (instancetype)initWithDelegate:(id <RDContainerDelegate>)delegate path:(NSString *)path {
+	if (path == nil || ![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+		return nil;
+	}
+
+	if (self = [super init]) {
+		m_delegate = delegate;
+
+		ePub3::ErrorHandlerFn sdkErrorHandler = ^(const ePub3::error_details& err) {
+
+			const char * msg = err.message();
+
+			BOOL isSevereEpubError = NO;
+			if (err.is_spec_error()
+					&& (err.severity() == ePub3::ViolationSeverity::Critical
+					|| err.severity() == ePub3::ViolationSeverity::Major))
+				isSevereEpubError = YES;
+
+			BOOL res = [m_delegate container:self handleSdkError:[NSString stringWithUTF8String:msg] isSevereEpubError:isSevereEpubError];
+
+			return (res == YES ? true : false);
+			//return ePub3::DefaultErrorHandler(err);
+		};
+		ePub3::SetErrorHandler(sdkErrorHandler);
+
+		ePub3::InitializeSdk();
+		ePub3::PopulateFilterManager();
+
+		m_path = path;
+		m_container = ePub3::Container::OpenContainer(path.UTF8String);
+
+		if (m_container == nullptr) {
+			return nil;
+		}
+
+		m_packageList = m_container->Packages();
+		m_packages = [[NSMutableArray alloc] initWithCapacity:4];
+
+		for (auto i = m_packageList.begin(); i != m_packageList.end(); i++) {
+			RDPackage *package = [[RDPackage alloc] initWithPackage:i->get()];
+			[m_packages addObject:package];
+		}
+	}
+
+	return self;
+}
+
+
+@end

--- a/SDKLauncher-iOS.xcodeproj/project.pbxproj
+++ b/SDKLauncher-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2BA722A51BE9AD470043D09B /* RDContainer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2BA722A31BE9AD470043D09B /* RDContainer.mm */; };
 		3403516516CE93F2009E3B88 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 3403516116CE93F2009E3B88 /* reader.css */; };
 		3403516616CE93F2009E3B88 /* reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 3403516216CE93F2009E3B88 /* reader.html */; };
 		340535AA16BC5DD100D4A802 /* BaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 340535A916BC5DD100D4A802 /* BaseViewController.m */; };
@@ -22,7 +23,6 @@
 		3413980B16C02DE7000912C1 /* ContainerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3413980A16C02DE7000912C1 /* ContainerController.m */; };
 		341652A316C2F85700AFDB8B /* PackageMetadataController.m in Sources */ = {isa = PBXBuildFile; fileRef = 341652A216C2F85700AFDB8B /* PackageMetadataController.m */; };
 		341652A816C2F9E700AFDB8B /* SpineItemListController.m in Sources */ = {isa = PBXBuildFile; fileRef = 341652A716C2F9E700AFDB8B /* SpineItemListController.m */; };
-		34212FB318F0649500A9109F /* RDContainer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34212F5F18F0649500A9109F /* RDContainer.mm */; };
 		34212FB418F0649500A9109F /* RDMediaOverlaysSmilModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34212F6118F0649500A9109F /* RDMediaOverlaysSmilModel.mm */; };
 		34212FB518F0649500A9109F /* RDNavigationElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34212F6318F0649500A9109F /* RDNavigationElement.mm */; };
 		34212FB618F0649500A9109F /* RDPackage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34212F6518F0649500A9109F /* RDPackage.mm */; };
@@ -161,6 +161,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2BA722A31BE9AD470043D09B /* RDContainer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RDContainer.mm; path = Classes/RDContainer.mm; sourceTree = SOURCE_ROOT; };
+		2BA722A41BE9AD470043D09B /* RDContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RDContainer.h; path = Classes/RDContainer.h; sourceTree = SOURCE_ROOT; };
 		3403516116CE93F2009E3B88 /* reader.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		3403516216CE93F2009E3B88 /* reader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = reader.html; sourceTree = "<group>"; };
 		340535A816BC5DD100D4A802 /* BaseViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseViewController.h; sourceTree = "<group>"; };
@@ -186,8 +188,6 @@
 		341652A616C2F9E700AFDB8B /* SpineItemListController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpineItemListController.h; sourceTree = "<group>"; };
 		341652A716C2F9E700AFDB8B /* SpineItemListController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpineItemListController.m; sourceTree = "<group>"; };
 		341A1F701790BC6800E603C4 /* host_app_feedback.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = host_app_feedback.js; sourceTree = "<group>"; };
-		34212F5E18F0649500A9109F /* RDContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDContainer.h; sourceTree = "<group>"; };
-		34212F5F18F0649500A9109F /* RDContainer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RDContainer.mm; sourceTree = "<group>"; };
 		34212F6018F0649500A9109F /* RDMediaOverlaysSmilModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDMediaOverlaysSmilModel.h; sourceTree = "<group>"; };
 		34212F6118F0649500A9109F /* RDMediaOverlaysSmilModel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RDMediaOverlaysSmilModel.mm; sourceTree = "<group>"; };
 		34212F6218F0649500A9109F /* RDNavigationElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDNavigationElement.h; sourceTree = "<group>"; };
@@ -451,8 +451,8 @@
 		34212F5D18F0649500A9109F /* Main */ = {
 			isa = PBXGroup;
 			children = (
-				34212F5E18F0649500A9109F /* RDContainer.h */,
-				34212F5F18F0649500A9109F /* RDContainer.mm */,
+				2BA722A31BE9AD470043D09B /* RDContainer.mm */,
+				2BA722A41BE9AD470043D09B /* RDContainer.h */,
 				34212F6018F0649500A9109F /* RDMediaOverlaysSmilModel.h */,
 				34212F6118F0649500A9109F /* RDMediaOverlaysSmilModel.mm */,
 				34212F6218F0649500A9109F /* RDNavigationElement.h */,
@@ -910,11 +910,11 @@
 				34C4064817A451D100354C33 /* EPubSettings.m in Sources */,
 				34212FC718F0649500A9109F /* HTTPAsyncFileResponse.m in Sources */,
 				34212FD318F0649500A9109F /* DDFileLogger.m in Sources */,
+				2BA722A51BE9AD470043D09B /* RDContainer.mm in Sources */,
 				34212FBA18F0649500A9109F /* RDPackageResourceServer.m in Sources */,
 				34C4064317A43A1700354C33 /* EPubSettingsController.m in Sources */,
 				3411DF03175FACC000FCE6D9 /* EPubViewController.m in Sources */,
 				34212FB418F0649500A9109F /* RDMediaOverlaysSmilModel.mm in Sources */,
-				34212FB318F0649500A9109F /* RDContainer.mm in Sources */,
 				34212FC318F0649500A9109F /* HTTPServer.m in Sources */,
 				340535B216BC608900D4A802 /* LocStr.m in Sources */,
 				34212FB718F0649500A9109F /* RDPackageResource.mm in Sources */,


### PR DESCRIPTION
Dear Readium SDK people.

I send a pull request for update SDKLauncher-ios.
This is to include unchanged RDContainer.mm/h files which are detached from the Readium SDK project.

The reason why those files are attached SDKLauncher-iOS rather than Readium SDK is:

1. Since RDContainer.mm needs to be modified to include LCP related header file and initialization code int the future, it is better to be in the SDKLauncher-iOS side in order to make Readium-SDK a DRM agnostic library.

2.  In Launcher-OSX case, the initialization process including  ePub3::InitializeSdk() is in the LauncherOSX/LOXePubSdkApi.mm file, not in the Readium SDK, which is pretty natural. 
  
The merge should be done together with disposal of the pull request of the Readium SDK.
Because only one disposal of either SDKLauncher-iOS or Readium SDK could make duplication or missing files problem.

And for the consistency of the Readium codes, in the future, we recommend all Launcher related files should locate at Launcher project instead of Readium SDK like Launcher-OSX case.

