### PR TITLE
Remove WKWebView scriptMessageHandler at clean up time

### DIFF
--- a/Classes/EPubViewController.m
+++ b/Classes/EPubViewController.m
@@ -113,6 +113,10 @@
 
 
 - (void)cleanUp {
+    if (m_webViewWK != nil) {
+        [m_webViewWK.configuration.userContentController removeScriptMessageHandlerForName:@"readium"];
+    }
+    
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	m_moIsPlaying = NO;
 

--- a/Classes/EPubViewController.m
+++ b/Classes/EPubViewController.m
@@ -113,10 +113,6 @@
 
 
 - (void)cleanUp {
-    if (m_webViewWK != nil) {
-        [m_webViewWK.configuration.userContentController removeScriptMessageHandlerForName:@"readium"];
-    }
-    
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	m_moIsPlaying = NO;
 


### PR DESCRIPTION
Fix potential EPubViewController leak by removing WKWebView's WKUserContentController script message handler in cleanUp(). The script message handler is set on WKUserContentController in EPubViewController::loadView.